### PR TITLE
Fix from clause liveins

### DIFF
--- a/numba/openmp.py
+++ b/numba/openmp.py
@@ -1454,12 +1454,16 @@ class openmp_region_start(ir.Stmt):
                 returnto=end_block,
                 body_block_ids=blocks_in_region
             )
-            def add_firstprivate_to_ins(ins, tags):
+
+            def add_mapped_to_ins(ins, tags):
                 for tag in tags:
-                    if tag.name == "QUAL.OMP.FIRSTPRIVATE" and tag.arg not in ins:
+                    if tag.arg in ins:
+                        continue
+
+                    if tag.name == "QUAL.OMP.FIRSTPRIVATE" or tag.name == "QUAL.OMP.MAP.FROM":
                         ins.append(tag.arg)
 
-            add_firstprivate_to_ins(ins, self.tags)
+            add_mapped_to_ins(ins, self.tags)
 
             normalized_ivs = get_tags_of_type(self.tags, "QUAL.OMP.NORMALIZED.IV")
             if config.DEBUG_OPENMP >= 1:
@@ -1856,6 +1860,7 @@ class openmp_region_start(ir.Stmt):
                 if config.DEBUG_OPENMP >= 1:
                     print('libomptarget_arch', libomptarget_arch)
                 subprocess.run([numba_openmp_bin_path + '/llvm-link',
+                    '--suppress-warnings',
                     '--internalize', '-S', filename_prefix +
                     '-intrinsics_omp.ll', libomptarget_arch, libdevice_path,
                     '-o', filename_prefix + '-intrinsics_omp-linked.ll'],

--- a/numba/openmp.py
+++ b/numba/openmp.py
@@ -1460,7 +1460,7 @@ class openmp_region_start(ir.Stmt):
                     if tag.arg in ins:
                         continue
 
-                    if tag.name == "QUAL.OMP.FIRSTPRIVATE" or tag.name == "QUAL.OMP.MAP.FROM":
+                    if tag.name in ["QUAL.OMP.FIRSTPRIVATE", "QUAL.OMP.MAP.FROM"]:
                         ins.append(tag.arg)
 
             add_mapped_to_ins(ins, self.tags)


### PR DESCRIPTION
The `from` clause must create an argument to the kernel function to return the value. The commit adds the variable tagged as `from` to the kernel function liveins.

Minor: it also suppresses a non-actionable warning of `llvm-link` in our internal CUDA pipeline.