### PR TITLE
Fix collapse loop

### DIFF
--- a/numba/openmp.py
+++ b/numba/openmp.py
@@ -2809,9 +2809,7 @@ def get_dotted_type(x, typemap, lowerer):
 
 
 def is_target_arg(name):
-    #return name in ["QUAL.OMP.FIRSTPRIVATE", "QUAL.OMP.TARGET.IMPLICIT", "QUAL.OMP.THREAD_LIMIT", "QUAL.OMP.NUM_TEAMS"] or name.startswith("QUAL.OMP.MAP")
-    #or name.startswith("QUAL.OMP.NORMALIZED")
-    return name in ["QUAL.OMP.FIRSTPRIVATE", "QUAL.OMP.TARGET.IMPLICIT"] or name.startswith("QUAL.OMP.MAP")
+    return name in ["QUAL.OMP.FIRSTPRIVATE", "QUAL.OMP.TARGET.IMPLICIT"] or name.startswith("QUAL.OMP.MAP") or name.startswith("QUAL.OMP.REDUCTION")
 
 
 def is_pointer_target_arg(name, typ):
@@ -2824,7 +2822,6 @@ def is_pointer_target_arg(name, typ):
     if name.startswith("QUAL.OMP.MAP"):
         if isinstance(typ, types.npytypes.Array):
             return True
-            #return False
         else:
             return True
     if name in ["QUAL.OMP.FIRSTPRIVATE", "QUAL.OMP.PRIVATE"]:
@@ -4342,7 +4339,8 @@ class OpenmpVisitor(Transformer):
         self.some_target_directive(args, "TARGET.TEAMS.DISTRIBUTE.PARALLEL.LOOP", 5, has_loop=True)
 
     def target_teams_distribute_parallel_for_simd_directive(self, args):
-        self.some_target_directive(args, "TARGET.TEAMS.DISTRIBUTE.PARALLEL.LOOP.SIMD", 6, has_loop=True)
+        # Intentionally dropping "SIMD" from string as that typically isn't implemented on GPU.
+        self.some_target_directive(args, "TARGET.TEAMS.DISTRIBUTE.PARALLEL.LOOP", 6, has_loop=True)
 
     def get_clauses_by_name(self, clauses, names, remove_from_orig=False):
         if not isinstance(names, list):

--- a/numba/tests/test_openmp.py
+++ b/numba/tests/test_openmp.py
@@ -4390,6 +4390,25 @@ class TestOpenmpTarget(TestOpenmpBase):
         else:
             raise ValueError(f"Device {device} must be 0 or 1")
 
+    def target_teams_loop_collapse(self, device):
+        target_pragma = f"""target teams loop collapse(2)
+                        device({device})
+                        map(tofrom: a, b, c)"""
+        @njit
+        def test_impl(n):
+            a = np.ones((n,n))
+            b = np.ones((n,n))
+            c = np.zeros((n,n))
+            with openmp(target_pragma):
+                for i in range(n):
+                    for j in range(n):
+                        c[i,j] = a[i,j] + b[i,j]
+            return c
+
+        n = 10
+        c = test_impl(n)
+        np.testing.assert_array_equal(c, np.full((n,n), 2))
+
 
 for memberName in dir(TestOpenmpTarget):
     if memberName.startswith("target"):


### PR DESCRIPTION
Allow other statements to be between the range declaration and its invocation in the Numba IR for the collapse clause.

Change target teams loop to not use simd.